### PR TITLE
Add consistent drop shadow to research highlight carousel images

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -174,7 +174,7 @@
         <h5>
         <b>ACM SIGGRAPH Asia 2023 Technical Papers</b>
         </h5>
-        <img height="350" width="350" src="publications/media/multicolor.png" class="off-glb">
+        <img height="350" width="350" src="publications/media/multicolor.png" class="off-glb baked-shadow">
         </div>
       </div>
       <div class="slide">
@@ -187,7 +187,7 @@
         <h5>
         <b>Optica Biomedical Optics Express 2023</b>
         </h5>
-        <img height="400" width="400" src="publications/media/learned_prescription.png" class="off-glb">
+        <img height="400" width="400" src="publications/media/learned_prescription.png" class="off-glb baked-shadow">
         </div>
       </div>
       <div class="slide">
@@ -200,7 +200,7 @@
         <h5>
         <b>IEEE VR 2023 Technical Papers</b>
         </h5>
-        <img height="350" width="350" src="publications/media/holobeam.png" class="off-glb">
+        <img height="350" width="350" src="publications/media/holobeam.png" class="off-glb baked-shadow">
         </div>
       </div>
       <div class="slide">
@@ -213,7 +213,7 @@
         <h5>
         <b>IEEE VR 2023 Technical Papers</b>
         </h5>
-        <img height="500" width="500" src="publications/media/realistic_defocus_cgh.png" class="off-glb">
+        <img height="500" width="500" src="publications/media/realistic_defocus_cgh.png" class="off-glb baked-shadow">
         </div>
       </div>
 

--- a/docs/stylesheets/carousel.css
+++ b/docs/stylesheets/carousel.css
@@ -54,6 +54,18 @@
   padding: 0;
 }
 
+/* All carousel images get a drop shadow by default, so any new research
+   highlight image added later automatically gets one too. */
+.slide img {
+  box-shadow: 5px 5px 12px rgba(0, 0, 0, 0.35);
+}
+
+/* Older teaser images already have a shadow baked into the PNG, so they
+   opt out of the CSS shadow to avoid a double shadow / white box. */
+.slide img.baked-shadow {
+  box-shadow: none;
+}
+
 @media screen and (min-width: 768px) {
   .carousel-button {
     font-size: 4rem;


### PR DESCRIPTION
Carousel images now get a CSS drop shadow by default via .slide img, so any new research highlight image automatically gets one. The older teaser images that already have a shadow baked into the PNG opt out via a baked-shadow class to avoid double shadows.